### PR TITLE
Updates to handle 6.9+ kernel changes

### DIFF
--- a/src/hook.h
+++ b/src/hook.h
@@ -17,8 +17,8 @@
  *
  ****************************************************************************/
 
-#ifndef _ROGUE_PUBLIC_HOOK_H
-#define _ROGUE_PUBLIC_HOOK_H
+#ifndef _INVARY_TEST_KIT_HOOK_H
+#define _INVARY_TEST_KIT_HOOK_H
 
 void hook_init(void);
 void hook_shutdown(void);

--- a/src/invary-test-kit.c
+++ b/src/invary-test-kit.c
@@ -22,6 +22,7 @@
 #include "hook.h"
 #include "textmod.h"
 #include "mem.h"
+#include "kprobe.h"
 #include "invary-test-kit.h"
 
 MODULE_LICENSE("GPL");
@@ -33,6 +34,7 @@ MODULE_VERSION(VERSION_STR);
 #include "hook.c"
 #include "textmod.c"
 #include "mem.c"
+#include "kprobe.c"
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(4, 16, 0)
 asmlinkage long invary_kill(const struct pt_regs* pt_regs);
@@ -52,6 +54,7 @@ int invary_test_kit_init(void) {
     kernel_symbol_init();
     hook_init();
     textmod_init();
+    kprobe_init();
     kernel_kill = (kernel_kill_t)hook_syscall(invary_kill, __NR_kill);
     printk(KERN_ALERT INVARY_TEST_KIT_TAG "initialized\n");
     return 0;
@@ -59,6 +62,7 @@ int invary_test_kit_init(void) {
 
 void invary_test_kit_exit(void) {
     printk(KERN_ALERT INVARY_TEST_KIT_TAG "exiting\n");
+    kprobe_shutdown();
     textmod_shutdown();
     hook_shutdown();
     printk(KERN_ALERT INVARY_TEST_KIT_TAG "exited\n");

--- a/src/kprobe.c
+++ b/src/kprobe.c
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ * Invary Test Kit Module
+ * Copyright (C) 2025 Invary, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the complete terms of the GNU General Public License, please see this URL:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ ****************************************************************************/
+
+#include <linux/module.h>
+#include <linux/kprobes.h>
+#include "invary-test-kit.h"
+
+/*
+ * The ability to modify the sys call table was removed in 6.9 and backported to other stable kernels
+ */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,5)) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,26)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,85)) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,154))
+#define KPROBE_NEEDED 1
+#endif
+
+#if KPROBE_NEEDED
+static int sys_kill_kprobe_pre_handler(struct kprobe *p, struct pt_regs *regs)
+{
+    pid_t pid = (pid_t) regs->di;
+    int sig = (int) regs->si;
+    printk(KERN_DEBUG INVARY_TEST_KIT_TAG "forwarding kill to kernel implementation: pid=%d, sig=%x\n", pid, sig);
+    return 0;
+}
+
+struct kprobe sys_kill_kprobe = {
+    .symbol_name = "__x64_sys_kill",
+    .pre_handler = sys_kill_kprobe_pre_handler,
+};
+
+void kprobe_init(void) {
+    int err;
+    err = register_kprobe(&sys_kill_kprobe);
+    if (err) {
+        pr_err("register_kprobe() failed: %d\n", err);
+    }
+}
+
+void kprobe_shutdown(void) {
+    unregister_kprobe(&sys_kill_kprobe);
+}
+#else
+// Dummy routines
+void kprobe_init(void) {
+}
+
+void kprobe_shutdown(void) {
+}
+#endif

--- a/src/kprobe.c
+++ b/src/kprobe.c
@@ -33,8 +33,9 @@
 #if KPROBE_NEEDED
 static int sys_kill_kprobe_pre_handler(struct kprobe *p, struct pt_regs *regs)
 {
-    pid_t pid = (pid_t) regs->di;
-    int sig = (int) regs->si;
+    struct pt_regs *user_regs = (struct pt_regs *) regs->di;
+    pid_t pid = (pid_t) user_regs->di;
+    int sig = (int) user_regs->si;
     printk(KERN_DEBUG INVARY_TEST_KIT_TAG "forwarding kill to kernel implementation: pid=%d, sig=%x\n", pid, sig);
     return 0;
 }

--- a/src/kprobe.c
+++ b/src/kprobe.c
@@ -30,7 +30,7 @@
 #define KPROBE_NEEDED 1
 #endif
 
-#if KPROBE_NEEDED
+#ifdef KPROBE_NEEDED
 static int sys_kill_kprobe_pre_handler(struct kprobe *p, struct pt_regs *regs)
 {
     struct pt_regs *user_regs = (struct pt_regs *) regs->di;

--- a/src/kprobe.h
+++ b/src/kprobe.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * Invary Test Kit Module
- * Copyright (C) 2023 Invary, Inc.
+ * Copyright (C) 2025 Invary, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,10 +17,10 @@
  *
  ****************************************************************************/
 
-#ifndef _INVARY_TEST_KIT_MEM_H
-#define _INVARY_TEST_KIT_MEM_H
+#ifndef _INVARY_TEST_KIT_KPROBE_H
+#define _INVARY_TEST_KIT_KPROBE_H
 
-inline void protect_memory(long unsigned int cr0);
-inline long unsigned int unprotect_memory(void);
+void kprobe_init(void);
+void kprobe_shutdown(void);
 
 #endif

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -17,8 +17,8 @@
  *
  ****************************************************************************/
 
-#ifndef _ROGUE_PUBLIC_SYMBOLS_H
-#define _ROGUE_PUBLIC_SYMBOLS_H
+#ifndef _INVARY_TEST_KIT_SYMBOLS_H
+#define _INVARY_TEST_KIT_SYMBOLS_H
 
 void kernel_symbol_init(void);
 unsigned long kernel_symbol_lookup(const char* symbol);

--- a/src/textmod.h
+++ b/src/textmod.h
@@ -17,8 +17,8 @@
  *
  ****************************************************************************/
 
-#ifndef _ROGUE_TEXTMOD_H
-#define _ROGUE_TEXTMOD_H
+#ifndef _INVARY_TEST_KIT_TEXTMOD_H
+#define _INVARY_TEST_KIT_TEXTMOD_H
 
 void textmod_init(void);
 void textmod_shutdown(void);


### PR DESCRIPTION
Move to kprobes as modifications to syscall table no longer work